### PR TITLE
修改错误显示

### DIFF
--- a/JPPlaygroundTool/JPPlayground.m
+++ b/JPPlaygroundTool/JPPlayground.m
@@ -19,6 +19,8 @@
 
 @property (nonatomic,strong) JPKeyCommands *keyManager;
 
+@property(nonatomic, strong) UIWindow *errorWindow;
+
 @property (nonatomic,strong) UIView *errorView;
 
 @property (nonatomic,strong) JPDevMenu *devMenu;
@@ -101,7 +103,9 @@ static void (^_reloadCompleteHandler)(void) = ^void(void) {
     }
     void(^exceptionhandler)(NSString *msg) = ^(NSString *msg){
         JPDevErrorView *errV = [[JPDevErrorView alloc]initError:msg];
-        [[UIApplication sharedApplication].keyWindow addSubview:errV];
+        [self.errorWindow addSubview:errV];
+        self.errorWindow.hidden = NO;
+        
         self.errorView = errV;
         [self.devMenu toggle];
     };
@@ -201,6 +205,7 @@ static void (^_reloadCompleteHandler)(void) = ^void(void) {
 #if TARGET_IPHONE_SIMULATOR
     [self.errorView removeFromSuperview];
     self.errorView = nil;
+    self.errorWindow.hidden = YES;
 #endif
 }
 
@@ -232,6 +237,16 @@ static void (^_reloadCompleteHandler)(void) = ^void(void) {
             break;
     }
 #endif
+}
+
+- (UIWindow *)errorWindow {
+    if (!_errorWindow) {
+        _errorWindow = [[UIWindow alloc] initWithFrame:CGRectMake(0, 0, [UIScreen mainScreen].bounds.size.width, 20)];
+        _errorWindow.windowLevel = UIWindowLevelStatusBar + 1.0f;
+        _errorWindow.backgroundColor = [UIColor blackColor];
+        [_errorWindow makeKeyAndVisible];
+    }
+    return _errorWindow;
 }
 
 #pragma clang diagnostic pop

--- a/JPPlaygroundTool/JPPlaygroundView/JPDevMenu.m
+++ b/JPPlaygroundTool/JPPlaygroundView/JPDevMenu.m
@@ -265,7 +265,7 @@ typedef NS_ENUM(NSInteger, JPDevMenuType) {
 
 -(void)actionSheet:(UIActionSheet *)actionSheet didDismissWithButtonIndex:(NSInteger)buttonIndex
 {
-    if (self.delegate && [self.delegate respondsToSelector:@selector(devMenuDidAction:withValue:)]) {
+    if ([self menuItems].count == buttonIndex && self.delegate && [self.delegate respondsToSelector:@selector(devMenuDidAction:withValue:)]) {
         [self.delegate devMenuDidAction:JPDevMenuActionCancel withValue:nil];
     }
 }


### PR DESCRIPTION
1. keyWindow有时候会被遮挡看不到的，使用了bang哥原来demo里的新加window的方法
2. 原先点击reload后错误一出现就会消失，改成了只有点cancel按钮才消失，不然完全看不见错误提示了